### PR TITLE
Add the "deployed_nodes" feature.

### DIFF
--- a/lib/xp5k/xp.rb
+++ b/lib/xp5k/xp.rb
@@ -8,17 +8,20 @@ module XP5K
 
     include Term::ANSIColor
 
-    attr_accessor :jobs, :jobs2submit, :deployments, :todeploy, :connection, :roles
-    attr_reader :starttime
+    attr_accessor :jobs, :jobs2submit, :deployments, :todeploy, :connection, :roles, :deployed_nodes
+    attr_reader :starttime, :links_deployments
 
     def initialize(options = {})
-      @jobs        = []
-      @jobs2submit = []
-      @deployments = []
-      @todeploy    = []
-      @roles       = []
-      @starttime   = Time.now
-      @logger      = options[:logger] || Logger.new(STDOUT)
+      @jobs               = []
+      @jobs2submit        = []
+      @deployments        = []
+      @todeploy           = []
+      @roles              = []
+      @links_deployments  = {"jobs" => {}, "roles" => {}}
+      @deployed_nodes     = {"jobs" => {}, "roles" => {}}
+      @starttime          = Time.now
+      @logger             = options[:logger] || Logger.new(STDOUT)
+
       XP5K::Config.load unless XP5K::Config.loaded?
 
       @connection = Restfully::Session.new(
@@ -53,18 +56,22 @@ module XP5K
           x[:nodes] += role_with_name(rolename).servers
         end
         deployment = @connection.root.sites[x[:site].to_sym].deployments.submit(x)
-        self.deployments << { :uid => deployment["uid"], :site => deployment["site_uid"], :status => deployment["status"]}
+        self.deployments << deployment
+        # update links_deployments
+        update_links_deployments(deployment["uid"], x)
       end
       logger.info "Waiting for all the deployments to be terminated..."
-      finished = self.deployments.reduce(true){ |acc, d| acc && d[:status]!='processing'}
+      finished = self.deployments.reduce(true){ |acc, d| acc && d["status"]!='processing'}
       while (!finished)
         sleep 10
         print "."
         self.deployments.each do |deployment|
-          deployment[:status] = @connection.root.sites[deployment[:site].to_sym].deployments[deployment[:uid].to_sym].reload["status"]
+          deployment.reload
         end
-        finished = self.deployments.reduce(true){ |acc, d| acc && d[:status]!='processing'}
+        finished = self.deployments.reduce(true){ |acc, d| acc && d["status"]!='processing'}
       end
+      update_deployed_nodes()
+      update_cache()
       print(" [#{green("OK")}]\n")
     end
 
@@ -72,7 +79,6 @@ module XP5K
       self.jobs2submit << job_hash
 
       if File.exists?(".xp_cache")
-        # Reload job
         datas = JSON.parse(File.read(".xp_cache"))
         uid = datas["jobs"].select { |x| x["name"] == job_hash[:name] }.first["uid"]
         unless uid.nil?
@@ -83,7 +89,10 @@ module XP5K
             create_roles(j, job_hash) unless job_hash[:roles].nil?
           end
         end
+        # reload last deployed nodes
+        self.deployed_nodes = datas["deployed_nodes"] 
       end
+
     end
 
     def submit
@@ -91,19 +100,21 @@ module XP5K
         job = self.job_with_name(job2submit[:name])
         if job.nil?
           job = @connection.root.sites[job2submit[:site].to_sym].jobs.submit(job2submit)
-          self.jobs << { :uid => job.properties['uid'], :name => job.properties['name'] }
+          #self.jobs << { :uid => job.properties['uid'], :name => job.properties['name'] }
           update_cache
           logger.info "Waiting for the job #{job["name"]} ##{job['uid']} to be running at #{job2submit[:site]}..."
           while job.reload["state"] != "running"
             print(".")
             sleep 3
           end
+          self.jobs << job 
           create_roles(job, job2submit) unless job2submit[:roles].nil?
           print(" [#{green("OK")}]\n")
         else
           logger.info "Job #{job["name"]} already submitted ##{job["uid"]}"
         end
       end
+      update_cache()
     end
 
     def create_roles(job, job_definition)
@@ -130,11 +141,16 @@ module XP5K
       self.roles.select { |x| x.name == name}.first
     end
 
-    def status
-      # self.jobs2submit.each do |job2submit|
-      #   job = self.job_with_name(job2submit[:name])
+    def get_deployed_nodes(job_or_role_name)
+      if deployed_nodes["jobs"].has_key?(job_or_role_name)
+        deployed_nodes["jobs"][job_or_role_name]
+      end
+      if deployed_nodes["roles"].has_key?(job_or_role_name)
+        deployed_nodes["roles"][job_or_role_name]
+      end
+    end
 
-      # end
+    def status
       self.jobs.each do |job|
         logger.info "Job #{job["name"]} ##{job["uid"]} status : #{job["state"]}"
       end
@@ -155,9 +171,53 @@ module XP5K
     def logger
       @logger
     end
+    
+    def update_links_deployments (duid, todeploy)
+      unless todeploy[:jobs].nil?
+        todeploy[:jobs].each do |job|
+          @links_deployments["jobs"][job] = duid  
+        end
+      end
 
+      unless todeploy[:roles].nil?
+        todeploy[:roles].each do |role|
+          @links_deployments["roles"][role] = duid  
+        end
+      end
+    end
+
+    def update_deployed_nodes
+      self.deployments.each do |deployment|
+        duid = deployment["uid"]
+        self.links_deployments["jobs"].select{|k,v| v == duid }.keys.each do |job_name|
+          job = job_with_name(job_name)
+          deployed_nodes["jobs"][job["name"]] = intersect_nodes_job(job, deployment)
+        end
+        self.links_deployments["roles"].select{|k,v| v == duid }.keys.each do |role_name|
+          role = role_with_name(role_name)
+          deployed_nodes["roles"][role.name] = intersect_nodes_role(role, deployment)
+        end
+
+      end
+    end
+    
+    def intersect_nodes_job (job, deployment)
+      nodes_deployed = deployment["result"].select{ |k,v| v["state"]=='OK'}.keys
+      job["assigned_nodes"] & nodes_deployed
+    end
+
+    def intersect_nodes_role (role, deployment)
+      nodes_deployed = deployment["result"].select{ |k,v| v["state"]=='OK'}.keys
+      role.servers & nodes_deployed
+    end
+    
     def update_cache
-      cache = { :jobs => self.jobs.map { |x| { :uid => x[:uid], :name => x[:name] } } }
+      cache = { 
+        :jobs               => self.jobs.collect { |x| x.properties },
+        :roles              => self.roles.map{ |x| { :name => x.name, :size => x.size, :servers => x.servers }},
+        :deployed_nodes     => self.deployed_nodes,
+        :links_deployments  => self.links_deployments
+      }
       open(".xp_cache", "w") do |f|
         f.puts cache.to_json
       end


### PR DESCRIPTION
once deployed a job (or a role) is associated to its "deployed nodes" list
which can differ from its "assigned_nodes" (or servers) list in case of failure during the deployment.

ADD
- attribute deployed_nodes to keep track of the deployed nodes for a given job a role.
- attribute links_deployments to keep track of the links between a job (or role) and a deployment uid.
- method update_links_deployment, called after a deployment submission to update the links_deployments attribute.
- method update_deployed_nodes, called after a deployment to update the deployed_nodes attribute.
- intersect_nodes_[job|role] method to intersect assigned and deployed nodes.
- get_deployed_nodes to retrieve the deployed of a given job or role.

MODIFY
- update_cache to cache restfully job property, roles, deployed_nodes and links_deployments
- add restfully jobs and deployments in self.jobs and self.deployments.

Matt
